### PR TITLE
Add car rental stubs and harden transport preferences

### DIFF
--- a/test_transportation_preferences.py
+++ b/test_transportation_preferences.py
@@ -1,0 +1,18 @@
+import json
+
+from preferences_manager import PreferencesManager
+
+
+def test_transportation_preferences_handles_string(tmp_path):
+    prefs_path = tmp_path / "prefs.json"
+    prefs_data = {
+        "transportation_preferences": "rideshare only",
+    }
+    prefs_path.write_text(json.dumps(prefs_data))
+
+    manager = PreferencesManager(str(prefs_path))
+    recommendations = manager.get_transportation_recommendations()
+
+    assert isinstance(recommendations["ground_transport"], dict)
+    assert isinstance(recommendations["car_rental"], dict)
+    assert isinstance(recommendations["preferred_car_type"], str)


### PR DESCRIPTION
## Summary
- add defensive handling for malformed transportation preference data
- introduce car rental search models and stubbed API integrations in the real API client
- add coverage ensuring transportation recommendations cope with unexpected input

## Testing
- pytest test_transportation_preferences.py
- pytest test_real_apis.py::test_real_apis -q
- pytest test_today.py::test_travel_apis_today -q

------
https://chatgpt.com/codex/tasks/task_e_68d61ba65fbc8323907925fc48cf612a